### PR TITLE
Fix solving objective functions of form "p = x+y+2" or similar

### DIFF
--- a/LPdefs.js
+++ b/LPdefs.js
@@ -73,7 +73,7 @@ var lp_noNiceSolutionErr = "No solution with the desired integer values exists"
 
 class lpProblem
 {
-	constructor ( problem = null ) {
+	constructor ( problem = null ) { // problem is itself an lpProblem
 			// linear expression to optimize
 		this.objective = (problem != null && typeof problem.objective == 'string') 
 							? problem.objective : "";			
@@ -122,6 +122,9 @@ class lpProblem
 			// similar for objective function
 		this.objectiveCoeffs = (problem != null && Array.isArray(problem.objectiveCoeffs))
 							? problem.objectiveCoeffs : [];
+			// e.g. the "2" in p = x+y+2
+		this.objectiveExtraConstant = (problem != null && typeof problem.objectiveExtraConstant == 'number') 
+								? problem.numActualUnknowns : 0;
 
 			// additional constraints used in integer programming, indexed like integerUnknowns
 		this.integerMins = (problem != null && Array.isArray(problem.integerMins))

--- a/LPmethods.js
+++ b/LPmethods.js
@@ -197,7 +197,7 @@ lpProblem.prototype.solve = function ()
 
 			splitProblem( p );			// again, these may throw errors
 			extractUnknowns( p );
-			extractCoefficients( p )
+			extractCoefficients( p );
 			createFirstTableau( p );
 			
 			p.status = lp_parsed;	// created tableau and unknowns from problem string
@@ -240,7 +240,7 @@ lpProblem.prototype.solve = function ()
 		else
 			throw lp_UnspecMaxMinErr;
 		
-		var coreObj = (obj.indexOf("subject") == -1) 
+		var coreObj = (obj.indexOf("subject") == -1)  // finds objective function!
 					  ? obj.substring(4)
 					  : obj.substring(4, Math.max(5,obj.indexOf("subject")-1));
 		if (coreObj.indexOf("=") > -1) 
@@ -270,7 +270,18 @@ lpProblem.prototype.solve = function ()
 		var outA = ("+"+p.objective)
 						.replace(/ /g,"")
 						.replace(/[\+\-][0-9.\/\(\)]*/g,",")
+						.replace(/,+/g,",") // removes strings of commas if there are constants in the objective function
 						.split(",");
+
+		if (outA[outA.length - 1] === '') { outA.pop(); }
+		
+		let objConstants = [...p.objective.matchAll(/\+([0-9]+)$/g)];
+		objConstants = objConstants.concat([...p.objective.matchAll(/\+([0-9]+)\+/g)]);
+
+		for (let i = 0; i < objConstants.length; i++) {
+			p.objectiveExtraConstant = p.objectiveExtraConstant + objConstants[i][1];
+		}
+
 		for ( var i=0; i < p.constraints.length; i++ )
 		{
 			var kA = ("+"+p.constraints[i])
@@ -394,7 +405,7 @@ lpProblem.prototype.solve = function ()
 		}
 		for (var j=1;j<numRows+1;j++)
 			firstTableau[i].push( (i!=j)? 0 : 1 );
-		firstTableau[i].push(0);
+		firstTableau[i].push(p.objectiveExtraConstant); // objective row value?
 			
 //		firstTableau.roundToSigDig(p.maxSigDigits); // round to avoid false negatives or non-zero elements
 		// Fix 01; in the first tableau there should be none of that, as no calculation is done prior to this


### PR DESCRIPTION
There's an issue with the current version of the LP calculator - inputting an objective function with a constant in it (e.g. `M = m-4` or `p = x+y+2`) doesn't correctly calculate the final value of the objective variable. It instead creates a column with an empty variable name in the tableau.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/48893229/214278904-09ea1291-12a7-439b-8b75-57ebc5ef3383.png">

I've fixed this by moving this constant to the RHS of the objective row. The algorithm then continues as usual.